### PR TITLE
Add basic test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.swp
 *~
 _output
+*.pyc
+*.pyo
+*__pycache__

--- a/test/hostpath_files/hostpath-class.yaml
+++ b/test/hostpath_files/hostpath-class.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: test-hostpath
+provisioner: example.com/hostpath

--- a/test/hostpath_files/hostpath-pv.yaml
+++ b/test/hostpath_files/hostpath-pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-test-hostpath
+spec:
+  capacity:
+    storage: 1Mi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /test
+  storageClassName: test-hostpath
+  claimRef:
+    apiVersion: v1
+    kind: PresistentVolumeClaim
+    namespace: default
+    name: pvc-test-hostpath

--- a/test/hostpath_files/hostpath-pvc.yaml
+++ b/test/hostpath_files/hostpath-pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-test-hostpath
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "test-hostpath"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi

--- a/test/hostpath_files/hostpath-snapshot.yaml
+++ b/test/hostpath_files/hostpath-snapshot.yaml
@@ -1,0 +1,6 @@
+apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: hostpath-test-snapshot
+spec:
+  persistentVolumeClaimName: pvc-test-hostpath

--- a/test/hostpath_files/promote-claim.yaml
+++ b/test/hostpath_files/promote-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-pv-provisioning-demo
+  namespace: myns
+  annotations:
+    snapshot.alpha.kubernetes.io/snapshot: snapshot-demo
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: 4Gi
+  storageClassName: snapshot-promoter

--- a/test/hostpath_files/snap-promoter-class.yaml
+++ b/test/hostpath_files/snap-promoter-class.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: snapshot-promoter
+provisioner: volumesnapshot.external-storage.k8s.io/snapshot-promoter
+

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+import argparse
+import unittest
+import snaptestcase
+import sys
+import os
+import subprocess
+import time
+import atexit
+
+def reap_process(proc):
+    proc.terminate()
+    proc.wait()
+
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    kubelog = sys.stdout
+    ctrllog = sys.stdout
+    provlog = sys.stdout
+
+    argparser = argparse.ArgumentParser(description='Volume Snapshotter test suite')
+    argparser.add_argument('-n', '--no-kubernetes', dest='nokube',
+                           help='don\'t start the kubernetes daemon')
+    argparser.add_argument('-k', '--kubelog', dest='kubelog',
+                           help='file to log kubernetes messaes to (default stdout)')
+    argparser.add_argument('-c', '--ctrllog', dest='ctrllog',
+                           help='file to log controller messaes to (default stdout)')
+    argparser.add_argument('-p', '--provlog', dest='provlog',
+                           help='file to log provisioner messaes to (default stdout)')
+    argparser.add_argument('testname', nargs='*',
+                           help='name of test class or method (e. g. "Hostpath")')
+    args = argparser.parse_args()
+
+    testdir = os.path.abspath(os.path.dirname(__file__))
+    snapsrcdir = os.path.abspath(os.path.join(testdir, '..'))
+    kubesrcdir = os.getenv('KUBESRCDIR', default=os.path.join(os.getenv('HOME'), 'kubernetes'))
+    snaptestcase.kubesrcdir = kubesrcdir
+
+
+    # find the kubernetes dir an start the cluster (if not disabled on commandline)
+    if not args.nokube:
+        if args.kubelog:
+            kubelog = open(args.kubelog, mode='w')
+        kubecmd = os.path.join(kubesrcdir, 'hack/local-up-cluster.sh')
+        # start the cluster
+        kubeoutputdir = os.path.join(kubesrcdir, '_output/local/bin/linux/amd64')
+        print("Starting " + kubecmd)
+        kube = subprocess.Popen([kubecmd + ' -o ' + kubeoutputdir],
+                shell=True, stdout=kubelog, stderr=kubelog, cwd=kubesrcdir)
+        # give the cluster some time to initialize
+        time.sleep(20)
+        kube.poll()
+        if kube.returncode != None:
+            print("Fatal: Unable to start the kubernetes cluster", file=sys.stderr)
+            sys.exit(1)
+        atexit.register(reap_process, kube)
+
+    kubeconfig = os.getenv('KUBECONFIG', '/var/run/kubernetes/admin.kubeconfig')
+    # start the controller
+    if args.ctrllog:
+        ctrllog = open(args.ctrllog, mode='w')
+    ctrlcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-controller')
+    ctrl = subprocess.Popen([ctrlcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
+            shell=True, stdout=ctrllog, stderr=ctrllog, cwd=snapsrcdir)
+    time.sleep(10)
+    ctrl.poll()
+    if ctrl.returncode != None:
+        print("Fatal: Unable to start the snapshot controller", file=sys.stderr)
+        sys.exit(1)
+    atexit.register(reap_process, ctrl)
+    # start the provisioner
+    if args.provlog:
+        ctrllog = open(args.provlog, mode='w')
+    provcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-controller')
+    prov = subprocess.Popen([provcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
+            shell=True, stdout=provlog, stderr=provlog, cwd=snapsrcdir)
+    time.sleep(10)
+    prov.poll()
+    if prov.returncode != None:
+        print("Fatal: Unable to start the snapshot provisioner", file=sys.stderr)
+        sys.exit(1)
+    atexit.register(reap_process, prov)
+
+    # Load all files in this directory whose name starts with 'test'
+    if args.testname:
+        for n in args.testname:
+            suite.addTests(unittest.TestLoader().loadTestsFromName(n))
+    else:
+        for test_cases in unittest.defaultTestLoader.discover(testdir):
+            suite.addTest(test_cases)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+
+    if result.wasSuccessful():
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/test/snaptestcase.py
+++ b/test/snaptestcase.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+import subprocess
+
+kubesrcdir = None
+
+class SnapTestCase(unittest.TestCase):
+    testdir = os.path.abspath(os.path.dirname(__file__))
+
+    @classmethod
+    def kubectl(self, kubeargs, ignore_error=False):
+        """
+        Shotrcut for kubectl process spawning
+        If ingnore_error is True tests will not fail on nonzero kubectl result
+        """
+        kube_command = kubesrcdir + '/cluster/kubectl.sh ' + kubeargs
+        print("Runnning ", kube_command)
+        res = subprocess.Popen(kube_command, shell=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+
+        out, _err = res.communicate()
+        retval = res.returncode
+        if not ignore_error and retval != 0:
+            raise AssertionError("kubectl returned nonzero exit code")
+        return (retval, out.decode().strip())
+
+    def findfile(self, filename):
+        """
+        Returns full path to a file named filename in the testing directory
+        """
+        return os.path.join(self.testdir, filename)

--- a/test/test_10_hostpath.py
+++ b/test/test_10_hostpath.py
@@ -1,0 +1,134 @@
+import unittest
+import snaptestcase
+import json
+import time
+import os
+
+class SnapHostpathTest(snaptestcase.SnapTestCase):
+    '''Basic HostPath based tests'''
+    def test_10_create(self):
+        """
+        Test creation of a PVC snapshot
+        """
+        # testing yaml files
+        classyaml = self.findfile('hostpath_files/hostpath-class.yaml')
+        pvyaml = self.findfile('hostpath_files/hostpath-pv.yaml')
+        pvcyaml = self.findfile('hostpath_files/hostpath-pvc.yaml')
+        snapyaml = self.findfile('hostpath_files/hostpath-snapshot.yaml')
+        test_snap_name = 'hostpath-test-snapshot'
+        # create StorageClass
+        self.kubectl('create -f ' + classyaml)
+        # create PV
+        self.kubectl('create -f ' + pvyaml)
+        # create PVC
+        self.kubectl('create -f ' + pvcyaml)
+
+        # get snapshots and snapshot data, count them
+        rv, out = self.kubectl('get volumesnapshot -o json')
+        json_out = json.loads(out)
+        snap_num_pre = len(json_out['items'])
+
+        rv, out = self.kubectl('get volumesnapshotdata -o json')
+        json_out = json.loads(out)
+        snap_data_num_pre = len(json_out['items'])
+        if snap_data_num_pre != 0:
+            print("*******")
+            print(out)
+            print("*******")
+
+        # snapshot PVC
+        self.kubectl('create -f ' + snapyaml)
+        time.sleep(3)
+
+        rv, out = self.kubectl('get volumesnapshot -o json')
+        snapshot_list = json.loads(out)
+        snap_num = len(snapshot_list['items'])
+        self.assertEqual(snap_num, snap_num_pre + 1)
+
+        # this may take time... try several times before giving up
+        for i in range(1, 10):
+            time.sleep(3)
+            rv, out = self.kubectl('get volumesnapshotdata -o json')
+            snapshot_data_list = json.loads(out)
+            snap_data_num = len(snapshot_data_list['items'])
+            if snap_data_num != snap_data_num_pre:
+                break
+        # this is super odd: dump the output
+        if snap_data_num != (snap_data_num_pre + 1):
+            print("*******")
+            print(out)
+            print("*******")
+
+        self.assertEqual(snap_data_num, snap_data_num_pre + 1)
+
+        # find the created snapshot in the list
+        created_snapshot = None
+        for snap in snapshot_list['items']:
+            if snap['metadata']['name'] == test_snap_name:
+                created_snapshot = snap
+                break
+        self.assertIsNotNone(created_snapshot)
+        # verify kubectl can find it
+        self.kubectl('get volumesnapshot ' + test_snap_name)
+
+        # find the corresponding snapshotdata
+        created_snapshot_data = None
+        for snap_data in snapshot_data_list['items']:
+            if snap_data['spec']['volumeSnapshotRef']['name'] == 'default/' + test_snap_name:
+                created_snapshot_data = snap_data
+                break
+        self.assertIsNotNone(created_snapshot_data)
+        # verify the snapshot really exists
+        snap_source = created_snapshot_data['spec']['hostPath']['snapshot']
+        self.assertIsNotNone(snap_source)
+        self.assertTrue(os.path.isfile(snap_source))
+
+    def test_20_delete(self):
+        """
+        Test deletion of a PVC snapshot
+        """
+        test_snap_name = 'hostpath-test-snapshot'
+        # get snapshots and snapshot data, count them
+        rv, out = self.kubectl('get volumesnapshot -o json')
+        json_out = json.loads(out)
+        snap_num_pre = len(json_out['items'])
+
+        rv, out = self.kubectl('get volumesnapshotdata -o json')
+        json_out = json.loads(out)
+        snap_data_num_pre = len(json_out['items'])
+
+        # remove snapshot
+        self.kubectl('delete volumesnapshot ' + test_snap_name)
+        time.sleep(1)
+
+        rv, out = self.kubectl('get volumesnapshot -o json')
+        snapshot_list = json.loads(out)
+        snap_num = len(snapshot_list['items'])
+        self.assertEqual(snap_num, snap_num_pre - 1)
+
+        rv, out = self.kubectl('get volumesnapshotdata -o json')
+        snapshot_data_list = json.loads(out)
+        snap_data_num = len(snapshot_data_list['items'])
+        self.assertEqual(snap_data_num, snap_data_num_pre - 1)
+
+        # find the created snapshot in the list
+        created_snapshot = None
+        for snap in snapshot_list['items']:
+            if snap['metadata']['name'] == test_snap_name:
+                created_snapshot = snap
+                break
+        self.assertIsNone(created_snapshot)
+        # verify kubectl can't find it
+        rv, out = self.kubectl('get volumesnapshot ' + test_snap_name, ignore_error=True)
+        self.assertNotEqual(rv, 0)
+
+        # find the corresponding snapshotdata
+        created_snapshot_data = None
+        for snap_data in snapshot_data_list['items']:
+            if snap_data['spec']['volumeSnapshotRef']['name'] == 'default/' + test_snap_name:
+                created_snapshot_data = snap_data
+                break
+        # none should be found
+        self.assertIsNone(created_snapshot_data)
+
+


### PR DESCRIPTION
Here's some basic python test scripts intended to be run by a CI. They test only creation/deletion with the HostPath plugin so far.

I'm not sure if Python is acceptable language but it seemed to be the fastest way to get something useful.