### PR TITLE
Fix bugs in create openstack snapshot

### DIFF
--- a/pkg/apis/crd/v1/types.go
+++ b/pkg/apis/crd/v1/types.go
@@ -235,6 +235,9 @@ func GetSupportedVolumeFromPVSpec(spec *core_v1.PersistentVolumeSpec) string {
 	if spec.GCEPersistentDisk != nil {
 		return "gce-pd"
 	}
+        if spec.Cinder != nil {
+                return "cinder"
+        }
 	return ""
 }
 

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -178,6 +178,16 @@ func (c *Caller) Call(f func()) {
 	}
 }
 
+func init() {
+        cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+                cfg, err := readConfig(config)
+                if err != nil {
+                        return nil, err
+                }
+                return newOpenStack(cfg)
+        })
+}
+
 func newOpenStack(cfg Config) (*OpenStack, error) {
 	provider, err := openstack.NewClient(cfg.Global.AuthUrl)
 	if err != nil {

--- a/pkg/cloudprovider/providers/openstack/openstack_snapshots.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_snapshots.go
@@ -73,6 +73,17 @@ func (snapshots *SnapshotsV2) createSnapshot(opts SnapshotCreateOpts) (string, e
 
 func (snapshots *SnapshotsV2) getSnapshot(snapshotID string) (Snapshot, error) {
 	var snap Snapshot
+        glog.Infof("getSnapshot for snapshotID: %s.", snapshotID)
+        snapshot, err := snapshotsV2.Get(snapshots.blockstorage, snapshotID).Extract()
+        if err != nil {
+                return snap, err
+        }
+        glog.Infof("Snapshot details: %#v", snapshot)
+        snap.ID = snapshot.ID
+        snap.Name = snapshot. Name
+        snap.Status = snapshot.Status
+        snap.SourceVolumeID = snapshot.VolumeID
+
 	return snap, nil
 }
 

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -91,6 +91,7 @@ func (volumes *VolumesV2) createVolume(opts VolumeCreateOpts) (string, string, e
 		VolumeType:       opts.VolumeType,
 		AvailabilityZone: opts.Availability,
 		Metadata:         opts.Metadata,
+		SnapshotID:       opts.SourceSnapshotID,
 	}
 
 	vol, err := volumesV2.Create(volumes.blockstorage, createOpts).Extract()

--- a/pkg/controller/cache/actual_state_of_world.go
+++ b/pkg/controller/cache/actual_state_of_world.go
@@ -77,7 +77,7 @@ func (asw *actualStateOfWorld) DeleteSnapshot(snapshotName string) error {
 	asw.Lock()
 	defer asw.Unlock()
 
-	glog.Infof("Deleteing snapshot from actual state of world: %s", snapshotName)
+	glog.Infof("Deleting snapshot from actual state of world: %s", snapshotName)
 	delete(asw.snapshots, snapshotName)
 	return nil
 }

--- a/pkg/controller/cache/desired_state_of_world.go
+++ b/pkg/controller/cache/desired_state_of_world.go
@@ -80,7 +80,7 @@ func (dsw *desiredStateOfWorld) DeleteSnapshot(snapshotName string) error {
 	dsw.Lock()
 	defer dsw.Unlock()
 
-	glog.Infof("Deleteing snapshot from desired state of world: %s", snapshotName)
+	glog.Infof("Deleting snapshot from desired state of world: %s", snapshotName)
 
 	delete(dsw.snapshots, snapshotName)
 	return nil


### PR DESCRIPTION
Fix the following issues in create openstack snapshot:

- Return “cinder” as supported volume from PV spec.
- Register openstack cloud provider.
- Get snapshot data.
- Specify snapshot id when creating volume from snapshot.
- Fix a couple of typos.