### PR TITLE
Snapshot controller flow rework

### DIFF
--- a/pkg/apis/crd/v1/types.go
+++ b/pkg/apis/crd/v1/types.go
@@ -44,8 +44,16 @@ type VolumeSnapshotConditionType string
 
 // These are valid conditions of a volume snapshot.
 const (
-	// VolumeSnapshotReady is added when the snapshot has been successfully created and is ready to be used.
+	// VolumeSnapshotConditionPending means the snapshot is cut and the application
+	// can resume accessing data if core_v1.ConditionStatus is True. It corresponds
+	// to "Uploading" in GCE PD or "Pending" in AWS and core_v1.ConditionStatus is True.
+	// It also corresponds to "Creating" in OpenStack Cinder and core_v1.ConditionStatus
+	// is Unknown.
+        VolumeSnapshotConditionPending VolumeSnapshotConditionType = "Pending"
+	// VolumeSnapshotConditionReady is added when the snapshot has been successfully created and is ready to be used.
 	VolumeSnapshotConditionReady VolumeSnapshotConditionType = "Ready"
+	// VolumeSnapshotConditionError means an error occurred during snapshot creation.
+        VolumeSnapshotConditionError VolumeSnapshotConditionType = "Error"
 )
 
 // VolumeSnapshot Condition describes the state of a volume snapshot  at a certain point.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -356,6 +356,9 @@ type Volumes interface {
 	// Describe an EBS volume snapshot status for create or delete.
 	// return status (completed or pending or error), and error
 	DescribeSnapshot(snapshotId string) (isCompleted bool, err error)
+
+	// Find snapshot by tags
+	FindSnapshot(tags map[string]string) (string, error)
 }
 
 // InstanceGroups is an interface for managing cloud-managed instance groups / autoscaling instance groups
@@ -1962,6 +1965,11 @@ func (c *Cloud) DescribeSnapshot(snapshotId string) (isCompleted bool, err error
 		return false, fmt.Errorf("snapshot state is error: %s", *result[0].StateMessage)
 	}
 	return false, fmt.Errorf(*result[0].StateMessage)
+}
+
+// FindSnapshot returns the found snapshot
+func (c *Cloud) FindSnapshot(tags map[string]string) (string, error) {
+	return "", nil
 }
 
 // Gets the current load balancer state

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -155,6 +155,9 @@ type Disks interface {
 	// return status (completed or pending or error), and error
 	DescribeSnapshot(snapshotToGet string) (isCompleted bool, err error)
 
+        // Find snapshot by tags
+        FindSnapshot(tags map[string]string) (string, error)
+
 	// GetAutoLabelsForPD returns labels to apply to PersistentVolume
 	// representing this PD, namely failure domain and zone.
 	// zone can be provided to specify the zone for the PD,
@@ -2857,6 +2860,11 @@ func (gce *GCECloud) DescribeSnapshot(snapshotToGet string) (isCompleted bool, e
 		return true, nil
 	}
 	return false, nil
+}
+
+// FindSnapshot returns the found snapshot
+func (gce *GCECloud) FindSnapshot(tags map[string]string) (string, error) {
+        return "", nil
 }
 
 func (gce *GCECloud) DeleteSnapshot(snapshotToDelete string) error {

--- a/pkg/volume/aws_ebs/processor.go
+++ b/pkg/volume/aws_ebs/processor.go
@@ -50,7 +50,7 @@ func (a *awsEBSPlugin) Init(cloud cloudprovider.Interface) {
 	a.cloud = cloud.(*aws.Cloud)
 }
 
-func (a *awsEBSPlugin) SnapshotCreate(pv *v1.PersistentVolume) (*crdv1.VolumeSnapshotDataSource, error) {
+func (a *awsEBSPlugin) SnapshotCreate(pv *v1.PersistentVolume, tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
 	spec := &pv.Spec
 	if spec == nil || spec.AWSElasticBlockStore == nil {
 		return nil, fmt.Errorf("invalid PV spec %v", spec)
@@ -92,6 +92,18 @@ func (a *awsEBSPlugin) DescribeSnapshot(snapshotData *crdv1.VolumeSnapshotData) 
 	}
 	snapshotId := snapshotData.Spec.AWSElasticBlockStore.SnapshotID
 	return a.cloud.DescribeSnapshot(snapshotId)
+}
+
+// FindSnapshot finds a VolumeSnapshot by matching metadata
+func (a *awsEBSPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
+        glog.Infof("FindSnapshot by tags: %#v", *tags)
+
+        // TODO: Implement FindSnapshot
+        return &crdv1.VolumeSnapshotDataSource{
+		AWSElasticBlockStore: &crdv1.AWSElasticBlockStoreVolumeSnapshotSource{
+			SnapshotID: "",
+                },
+        }, nil
 }
 
 func (a *awsEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, pvc *v1.PersistentVolumeClaim, pvName string, parameters map[string]string) (*v1.PersistentVolumeSource, map[string]string, error) {

--- a/pkg/volume/gce_pd/processor.go
+++ b/pkg/volume/gce_pd/processor.go
@@ -54,7 +54,7 @@ func (plugin *gcePersistentDiskPlugin) Init(cloud cloudprovider.Interface) {
 	plugin.cloud = cloud.(*gce.GCECloud)
 }
 
-func (plugin *gcePersistentDiskPlugin) SnapshotCreate(pv *v1.PersistentVolume) (*crdv1.VolumeSnapshotDataSource, error) {
+func (plugin *gcePersistentDiskPlugin) SnapshotCreate(pv *v1.PersistentVolume, tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
 	spec := &pv.Spec
 	if spec == nil || spec.GCEPersistentDisk == nil {
 		return nil, fmt.Errorf("invalid PV spec %v", spec)
@@ -64,12 +64,12 @@ func (plugin *gcePersistentDiskPlugin) SnapshotCreate(pv *v1.PersistentVolume) (
 	snapshotName := createSnapshotName(string(pv.Name))
 	glog.Infof("Jing snapshotName %s", snapshotName)
 	// Gather provisioning options
-	tags := make(map[string]string)
+	//tags := make(map[string]string)
 	//tags["kubernetes.io/created-for/snapshot/namespace"] = claim.Namespace
 	//tags[CloudVolumeCreatedForClaimNameTag] = claim.Name
 	//tags[CloudVolumeCreatedForVolumeNameTag] = pvName
 
-	err := plugin.cloud.CreateSnapshot(diskName, zone, snapshotName, tags)
+	err := plugin.cloud.CreateSnapshot(diskName, zone, snapshotName, *tags)
 	if err != nil {
 		return nil, err
 	}
@@ -173,6 +173,18 @@ func (plugin *gcePersistentDiskPlugin) DescribeSnapshot(snapshotData *crdv1.Volu
 	}
 	snapshotId := snapshotData.Spec.GCEPersistentDiskSnapshot.SnapshotName
 	return plugin.cloud.DescribeSnapshot(snapshotId)
+}
+
+// FindSnapshot finds a VolumeSnapshot by matching metadata
+func (a *gcePersistentDiskPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
+        glog.Infof("FindSnapshot by tags: %#v", *tags)
+
+        // TODO: Implement FindSnapshot
+        return &crdv1.VolumeSnapshotDataSource{
+                GCEPersistentDiskSnapshot: &crdv1.GCEPersistentDiskSnapshotSource{
+                        SnapshotName: "",
+                },
+        }, nil
 }
 
 func (plugin *gcePersistentDiskPlugin) VolumeDelete(pv *v1.PersistentVolume) error {

--- a/pkg/volume/hostpath/processor.go
+++ b/pkg/volume/hostpath/processor.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/pkg/api/v1"
 
+        "github.com/golang/glog"
 	crdv1 "github.com/rootfs/snapshot/pkg/apis/crd/v1"
 	"github.com/rootfs/snapshot/pkg/cloudprovider"
 	"github.com/rootfs/snapshot/pkg/volume"
@@ -50,7 +51,7 @@ func GetPluginName() string {
 func (h *hostPathPlugin) Init(_ cloudprovider.Interface) {
 }
 
-func (h *hostPathPlugin) SnapshotCreate(pv *v1.PersistentVolume) (*crdv1.VolumeSnapshotDataSource, error) {
+func (h *hostPathPlugin) SnapshotCreate(pv *v1.PersistentVolume, tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
 	spec := &pv.Spec
 	if spec == nil || spec.HostPath == nil {
 		return nil, fmt.Errorf("invalid PV spec %v", spec)
@@ -83,6 +84,18 @@ func (a *hostPathPlugin) DescribeSnapshot(snapshotData *crdv1.VolumeSnapshotData
 		return false, err
 	}
 	return true, nil
+}
+
+// FindSnapshot finds a VolumeSnapshot by matching metadata
+func (a *hostPathPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error) {
+        glog.Infof("FindSnapshot by tags: %#v", *tags)
+
+	// TODO: Implement FindSnapshot
+        return &crdv1.VolumeSnapshotDataSource{
+                HostPath: &crdv1.HostPathVolumeSnapshotSource{
+                        Path: "",
+                },
+        }, nil
 }
 
 func (h *hostPathPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, _ *v1.PersistentVolumeClaim, _ string, _ map[string]string) (*v1.PersistentVolumeSource, map[string]string, error) {

--- a/pkg/volume/interface.go
+++ b/pkg/volume/interface.go
@@ -27,7 +27,7 @@ type VolumePlugin interface {
 	// Init inits volume plugin
 	Init(cloudprovider.Interface)
 	// SnapshotCreate creates a VolumeSnapshot from a PersistentVolumeSpec
-	SnapshotCreate(*v1.PersistentVolume) (*crdv1.VolumeSnapshotDataSource, error)
+	SnapshotCreate(*v1.PersistentVolume, *map[string]string) (*crdv1.VolumeSnapshotDataSource, error)
 	// SnapshotDelete deletes a VolumeSnapshot
 	// PersistentVolume is provided for volume types, if any, that need PV Spec to delete snapshot
 	SnapshotDelete(*crdv1.VolumeSnapshotDataSource, *v1.PersistentVolume) error
@@ -36,6 +36,8 @@ type VolumePlugin interface {
 	// Describe an EBS volume snapshot status for create or delete.
 	// return status (completed or pending or error), and error
 	DescribeSnapshot(snapshotData *crdv1.VolumeSnapshotData) (isCompleted bool, err error)
+	// FindSnapshot finds a VolumeSnapshot by matching metadata
+	FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnapshotDataSource, error)
 	// VolumeDelete deletes a PV
 	// TODO in the future pass kubernetes client for certain volumes (e.g. rbd) so they can access storage class to retrieve secret
 	VolumeDelete(pv *v1.PersistentVolume) error


### PR DESCRIPTION
This patch modified the snapshot controller flow. It works as follows:
	1. Check the status of VolumeSnapshot object and determine the next step.
        2. Retrieve metadata from VolumeSnapshot object if existing;
           otherwise create metadata and update VolumeSnapshot object.
           If metadata pre-existing, find snapshot through volume plugin;
           If metadata newly created, take snapshot through volume plugin.
        3. Create VolumeSnapshotData object with a reference to the snapshot by the plugin.
           Update VolumeSnapshot object status and also bind VolumeSnapshotData to VolumeSnapshot.
        4. Query the volume plugin for the status of the snapshot with snapshot id
           from VolumeSnapshotData object until snapshot is ready.
	   Update VolumeSnapshot and VolumeSnapshotData.

Also added FindSnapshot (find snapshot by metadata) in the cloudprovider.
Implemented for OpenStack, not for AWS and GCE yet.